### PR TITLE
storage/mysql: Add enum support via TEXT COLUMNS option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4716,6 +4716,7 @@ dependencies = [
  "prost",
  "prost-build",
  "protobuf-src",
+ "regex",
  "serde",
  "thiserror",
  "tonic-build",

--- a/src/mysql-util/Cargo.toml
+++ b/src/mysql-util/Cargo.toml
@@ -25,6 +25,7 @@ once_cell = "1.16.0"
 prost = { version = "0.11.3", features = ["no-recursion-limit"] }
 proptest = { version = "1.0.0", default-features = false, features = ["std"] }
 proptest-derive = { version = "0.3.0", features = ["boxed_union"]}
+regex = "1.7.0"
 serde = { version = "1.0.152", features = ["derive"] }
 thiserror = "1.0.37"
 tracing = "0.1.37"

--- a/src/mysql-util/src/decoding.rs
+++ b/src/mysql-util/src/decoding.rs
@@ -19,6 +19,7 @@ use mz_repr::adt::numeric::{get_precision, get_scale, Numeric, NUMERIC_DATUM_MAX
 use mz_repr::adt::timestamp::CheckedTimestamp;
 use mz_repr::{Datum, Row, ScalarType};
 
+use crate::desc::MySqlColumnMeta;
 use crate::{MySqlColumnDesc, MySqlError, MySqlTableDesc};
 
 pub fn pack_mysql_row(
@@ -105,8 +106,43 @@ fn val_to_datum<'a>(
                 Datum::from(temp_strs.last().unwrap().as_str())
             }
             ScalarType::String => {
-                temp_strs.push(from_value_opt::<String>(value)?);
-                Datum::from(temp_strs.last().unwrap().as_str())
+                // Special case for string types, since this is the scalar type used for a column
+                // specified as a 'TEXT COLUMN'. In some cases we need to check the column
+                // metadata to know if the upstream value needs special handling
+                match &col_desc.meta {
+                    Some(MySqlColumnMeta::Enum(e)) => {
+                        match value {
+                            Value::Bytes(data) => {
+                                let data = std::str::from_utf8(&data)?;
+                                temp_strs.push(data.to_string());
+                                Datum::from(temp_strs.last().unwrap().as_str())
+                            }
+                            Value::Int(val) => {
+                                // Enum types are provided as 1-indexed integers in the replication
+                                // stream, so we need to find the string value from the enum meta
+                                let enum_val = e
+                                    .values
+                                    .get(usize::try_from(val)? - 1)
+                                    .ok_or(anyhow::anyhow!(
+                                        "received invalid enum value: {} for column {}",
+                                        val,
+                                        col_desc.name
+                                    ))?
+                                    .clone();
+                                temp_strs.push(enum_val);
+                                Datum::from(temp_strs.last().unwrap().as_str())
+                            }
+                            _ => Err(anyhow::anyhow!(
+                                "received unexpected value for enum type: {:?}",
+                                value
+                            ))?,
+                        }
+                    }
+                    _ => {
+                        temp_strs.push(from_value_opt::<String>(value)?);
+                        Datum::from(temp_strs.last().unwrap().as_str())
+                    }
+                }
             }
             ScalarType::Bytes => {
                 let data = from_value_opt::<Vec<u8>>(value)?;

--- a/src/mysql-util/src/desc.proto
+++ b/src/mysql-util/src/desc.proto
@@ -20,9 +20,17 @@ message ProtoMySqlTableDesc {
     repeated ProtoMySqlKeyDesc keys = 4;
 }
 
+message ProtoMySqlColumnMetaEnum {
+    repeated string values = 1;
+}
+
 message ProtoMySqlColumnDesc {
     string name = 1;
     mz_repr.relation_and_scalar.ProtoColumnType column_type = 2;
+
+    oneof meta {
+        ProtoMySqlColumnMetaEnum enum = 3;
+    }
 }
 
 message ProtoMySqlKeyDesc {

--- a/src/mysql-util/src/schemas.rs
+++ b/src/mysql-util/src/schemas.rs
@@ -10,6 +10,8 @@
 use std::collections::{BTreeMap, BTreeSet};
 
 use itertools::Itertools;
+use once_cell::sync::Lazy;
+use regex::Regex;
 
 use mysql_async::prelude::{FromRow, Queryable};
 use mysql_async::{FromRowError, Row};
@@ -20,14 +22,10 @@ use mz_repr::adt::timestamp::TimestampPrecision;
 use mz_repr::adt::varchar::VarCharMaxLength;
 use mz_repr::{ColumnType, ScalarType};
 
-use crate::desc::{MySqlColumnDesc, MySqlKeyDesc, MySqlTableDesc};
+use crate::desc::{
+    MySqlColumnDesc, MySqlColumnMeta, MySqlColumnMetaEnum, MySqlKeyDesc, MySqlTableDesc,
+};
 use crate::{MySqlError, UnsupportedDataType};
-
-/// The types that we support being casted as TEXT COLUMNS. This is the set of types that is
-/// represented as an encoded-string in both the mysql-common binary query response and binlog
-/// event representation, OR it's a type that we've added explicit casting support for.
-// TODO: Add `enum` support
-const SUPPORTED_TEXT_COLUMN_TYPES: &[&str] = &["json"];
 
 /// Helper for querying information_schema.columns
 // NOTE: The order of these names *must* match the order of fields of the [`InfoSchema`] struct.
@@ -180,22 +178,17 @@ where
             // treat it as a string and skip type parsing.
             if let Some(text_columns) = table_text_cols {
                 if text_columns.contains(&info.column_name.as_str()) {
-                    if !SUPPORTED_TEXT_COLUMN_TYPES.contains(&info.data_type.as_str()) {
-                        error_cols.push(UnsupportedDataType {
-                            column_type: info.column_type.clone(),
-                            qualified_table_name: format!("{:?}.{:?}", schema_name, table_name),
-                            column_name: info.column_name.clone(),
-                            intended_type: Some("text".to_string()),
-                        });
-                        continue;
+                    match parse_as_text_column(&info, &schema_name, &table_name) {
+                        Err(err) => error_cols.push(err),
+                        Ok((scalar_type, meta)) => columns.push(MySqlColumnDesc {
+                            name: info.column_name,
+                            column_type: ColumnType {
+                                scalar_type,
+                                nullable: &info.is_nullable == "YES",
+                            },
+                            meta,
+                        }),
                     }
-                    columns.push(MySqlColumnDesc {
-                        name: info.column_name,
-                        column_type: ColumnType {
-                            scalar_type: ScalarType::String,
-                            nullable: &info.is_nullable == "YES",
-                        },
-                    });
                     continue;
                 }
             }
@@ -209,6 +202,7 @@ where
                         scalar_type,
                         nullable: &info.is_nullable == "YES",
                     },
+                    meta: None,
                 }),
             }
         }
@@ -375,5 +369,70 @@ fn parse_data_type(
             column_name: info.column_name.clone(),
             intended_type: None,
         }),
+    }
+}
+
+/// Parse the specified column as a TEXT COLUMN. We only support the set of types that are
+/// represented as an encoded-string in both the mysql-common binary query response and binlog
+/// event representation, OR types that we've added explicit casting support for.
+fn parse_as_text_column(
+    info: &InfoSchema,
+    schema_name: &str,
+    table_name: &str,
+) -> Result<(ScalarType, Option<MySqlColumnMeta>), UnsupportedDataType> {
+    match info.data_type.as_str() {
+        "json" => Ok((ScalarType::String, None)),
+        "enum" => Ok((
+            ScalarType::String,
+            Some(MySqlColumnMeta::Enum(MySqlColumnMetaEnum {
+                values: enum_vals_from_column_type(info.column_type.as_str()).map_err(|_| {
+                    UnsupportedDataType {
+                        column_type: info.column_type.clone(),
+                        qualified_table_name: format!("{:?}.{:?}", schema_name, table_name),
+                        column_name: info.column_name.clone(),
+                        intended_type: Some("text".to_string()),
+                    }
+                })?,
+            })),
+        )),
+        _ => Err(UnsupportedDataType {
+            column_type: info.column_type.clone(),
+            qualified_table_name: format!("{:?}.{:?}", schema_name, table_name),
+            column_name: info.column_name.clone(),
+            intended_type: Some("text".to_string()),
+        }),
+    }
+}
+
+static ENUM_VAL_REGEX: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"'((?:[^']|'')*)'").expect("valid regex"));
+
+/// Parse the enum values from a column_type value on an enum column, which is a string like
+/// "enum('apple','banana','cher,ry','ora''nge')"
+/// We need to handle the case where the enum value itself contains a comma or a
+/// single quote (escaped with another quote), so we use a regex to do so
+fn enum_vals_from_column_type(s: &str) -> Result<Vec<String>, anyhow::Error> {
+    let vals_str = s
+        .strip_prefix("enum(")
+        .and_then(|s| s.strip_suffix(")"))
+        .ok_or(anyhow::format_err!(
+            "Unable to parse enum column type string"
+        ))?;
+
+    Ok(ENUM_VAL_REGEX
+        .captures_iter(vals_str)
+        .map(|s| s[1].to_string())
+        .collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[mz_ore::test]
+    fn test_enum_value_parsing() {
+        let vals =
+            enum_vals_from_column_type("enum('apple','banana','cher,ry','ora''nge')").unwrap();
+        assert_eq!(vals, vec!["apple", "banana", "cher,ry", "ora''nge"]);
     }
 }

--- a/test/mysql-cdc/30-text-columns.td
+++ b/test/mysql-cdc/30-text-columns.td
@@ -28,13 +28,13 @@ $ mysql-execute name=mysql
 DROP DATABASE IF EXISTS public;
 CREATE DATABASE public;
 USE public;
-CREATE TABLE t1 (f1 JSON);
+CREATE TABLE t1 (f1 JSON, f2 ENUM('small', 'medium', 'large'));
 
-INSERT INTO t1 VALUES (CAST('{"bar": "baz", "balance": 7.77, "active": false}' AS JSON));
+INSERT INTO t1 VALUES (CAST('{"bar": "baz", "balance": 7.77, "active": false}' AS JSON), 'large');
 
 > CREATE SOURCE da
   FROM MYSQL CONNECTION mysqc (
-    TEXT COLUMNS (public.t1.f1)
+    TEXT COLUMNS (public.t1.f1, public.t1.f2)
   )
   FOR TABLES (public.t1);
 
@@ -46,6 +46,10 @@ INSERT INTO t1 SELECT * FROM t1;
 > SELECT f1::jsonb->>'balance' FROM t1;
 7.77
 7.77
+
+> SELECT f2 FROM t1;
+"large"
+"large"
 
 #
 # Validate that unsupported types error even as TEXT COLUMNS


### PR DESCRIPTION
### Motivation

Draft until https://github.com/MaterializeInc/materialize/pull/25483 is merged

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
